### PR TITLE
Filter out topics that are blocked by throwing an exception

### DIFF
--- a/src/main/kotlin/app/batch/HttpWriter.kt
+++ b/src/main/kotlin/app/batch/HttpWriter.kt
@@ -2,6 +2,7 @@ package app.batch
 
 import app.configuration.HttpClientProvider
 import app.domain.DecryptedStream
+import app.exceptions.BlockedTopicException
 import app.exceptions.MetadataException
 import app.exceptions.WriterException
 import app.services.ExportStatusService
@@ -49,26 +50,23 @@ class HttpWriter(private val httpClientProvider: HttpClientProvider,
     }
 
     private fun postItem(item: DecryptedStream) {
+
         logger.info("Checking item to  write", "file_name" to item.fileName, "full_path" to item.fullPath)
+
         val match = filenameRe.find(item.fileName)
-        if (match == null) {
-            val errorMessage = "Rejecting: '${item.fullPath}' as fileName does not match '$filenameRe'"
-            val exception = MetadataException(errorMessage)
-            logger.error("Rejecting item to write", exception, "file_name" to item.fullPath, "expected_file_name" to filenameRe.toString())
-            throw exception
-        }
+        checkMatchIsNotNull(match, item)
 
         val lastDashIndex = item.fileName.lastIndexOf("-")
-        if (lastDashIndex < 0) {
-            val errorMessage = "Rejecting: '${item.fullPath}' as fileName does not contain '-' to find number"
-            val exception = MetadataException(errorMessage)
-            logger.error("Rejecting item to write", exception, "file_name" to item.fullPath)
-            throw exception
-        }
-        val database = match.groupValues[1]
+        checkLastDashIndexIsPositive(lastDashIndex, item)
+
+        val database = match!!.groupValues[1]
         val collection = match.groupValues[2].replace(Regex("""(-\d{3}-\d{3})?-\d+$"""), "")
+
         val topic = "db.$database.$collection"
+        isTopicBlocked(topic, item)
+
         val filenameHeader = item.fileName.replace(Regex("""\.txt\.gz$"""), ".json.gz")
+
         logger.info("Posting file name to collection",
                 "database" to database,
                 "collection" to collection,
@@ -77,8 +75,8 @@ class HttpWriter(private val httpClientProvider: HttpClientProvider,
                 "full_path" to item.fullPath,
                 "nifi_url" to nifiUrl,
                 "filename_header" to filenameHeader)
-        httpClientProvider.client().use {
 
+        httpClientProvider.client().use { it ->
             val post = HttpPost(nifiUrl).apply {
                 entity = InputStreamEntity(item.inputStream, -1, ContentType.DEFAULT_BINARY)
                 setHeader("filename", filenameHeader)
@@ -100,7 +98,6 @@ class HttpWriter(private val httpClientProvider: HttpClientProvider,
                         s3StatusFileWriter.writeStatus(item.fullPath)
                     }
                     else -> {
-
                         val headers = mutableListOf<Pair<String, String>>()
                         response.allHeaders.forEach {
                             headers.add(it.name to it.value)
@@ -110,10 +107,38 @@ class HttpWriter(private val httpClientProvider: HttpClientProvider,
                                 "file_name" to item.fullPath,
                                 "response" to response.statusLine.statusCode.toString(),
                                 "nifi_url" to nifiUrl, *headers.toTypedArray())
+
                         throw WriterException("Failed to post '${item.fullPath}': post returned status code ${response.statusLine.statusCode}")
                     }
                 }
             }
+        }
+    }
+
+    private fun checkMatchIsNotNull(match: MatchResult?, item: DecryptedStream) {
+        if (match == null) {
+            val errorMessage = "Rejecting: '${item.fullPath}' as fileName does not match '$filenameRe'"
+            val exception = MetadataException(errorMessage)
+            logger.error("Rejecting item to write", exception, "file_name" to item.fullPath, "expected_file_name" to filenameRe.toString())
+            throw exception
+        }
+    }
+
+    private fun checkLastDashIndexIsPositive(lastDashIndex: Int, item: DecryptedStream) {
+        if (lastDashIndex < 0) {
+            val errorMessage = "Rejecting: '${item.fullPath}' as fileName does not contain '-' to find number"
+            val exception = MetadataException(errorMessage)
+            logger.error("Rejecting item to write", exception, "file_name" to item.fullPath)
+            throw exception
+        }
+    }
+
+    private fun isTopicBlocked(topic: String, item: DecryptedStream) {
+        if (blockedTopics.contains(topic)) {
+            val errorMessage = "Provided topic is blocked so cannot be processed: '$topic'"
+            val exception = BlockedTopicException(errorMessage)
+            logger.error("Provided topic is blocked", exception, "topic_name" to topic, "file_name" to item.fullPath)
+            throw exception
         }
     }
 
@@ -123,8 +148,10 @@ class HttpWriter(private val httpClientProvider: HttpClientProvider,
     @Value("\${export.date}")
     private lateinit var exportDate: String
 
+    @Value("\${blocked.topics:NOT_SET}")
+    lateinit var blockedTopics: String
+
     companion object {
         val logger = DataworksLogger.getLogger(HttpWriter::class.toString())
     }
-
 }

--- a/src/main/kotlin/app/exceptions/Exceptions.kt
+++ b/src/main/kotlin/app/exceptions/Exceptions.kt
@@ -9,3 +9,5 @@ class WriterException(message: String) : Exception(message)
 class SuccessException(message: String) : Exception(message)
 
 class MetadataException(message: String) : Exception(message)
+
+class BlockedTopicException(message: String): Exception(message)

--- a/src/test/kotlin/app/batch/HttpWriterTest.kt
+++ b/src/test/kotlin/app/batch/HttpWriterTest.kt
@@ -73,7 +73,6 @@ class HttpWriterTest {
 
     val byteArray = "hello, world".toByteArray()
     val s3Path = "exporter-output/job01" //should match the test properties above
-    val blockedTopicName = "db.crypto.unencrypted"
 
     @Before
     fun before() {
@@ -254,7 +253,7 @@ class HttpWriterTest {
     }
 
     @Test
-    fun willIncrementFilesSentCountOnSuccessfullPost() {
+    fun willIncrementFilesSentCountOnSuccessfulPost() {
         val filename = "db.database.collection-000001.txt.gz"
         val decryptedStream = DecryptedStream(ByteArrayInputStream(byteArray), filename, "$s3Path/$filename")
 
@@ -266,7 +265,7 @@ class HttpWriterTest {
             on { statusLine } doReturn okStatusLine
         }
 
-        val httpClient = mock<CloseableHttpClient>() {
+        val httpClient = mock<CloseableHttpClient> {
             on { execute(any()) } doReturn response
         }
 
@@ -289,7 +288,7 @@ class HttpWriterTest {
             on { allHeaders } doReturn arrayOf(mock<Header>())
         }
 
-        val httpClient = mock<CloseableHttpClient>() {
+        val httpClient = mock<CloseableHttpClient> {
             on { execute(any()) } doReturn response
         }
 
@@ -303,20 +302,6 @@ class HttpWriterTest {
         val filename = "db.crypto.unencrypted-000001.txt.gz"
         val decryptedStream = DecryptedStream(ByteArrayInputStream(byteArray), filename, "$s3Path/$filename")
 
-        val okStatusLine = mock<StatusLine> {
-            on { statusCode } doReturn 503
-        }
-
-        val response = mock<CloseableHttpResponse> {
-            on { statusLine } doReturn okStatusLine
-            on { allHeaders } doReturn arrayOf(mock<Header>())
-        }
-
-        val httpClient = mock<CloseableHttpClient>() {
-            on { execute(any()) } doReturn response
-        }
-
-        given(httpClientProvider.client()).willReturn(httpClient)
         httpWriter.write(mutableListOf(decryptedStream))
         verifyZeroInteractions(exportStatusService)
     }

--- a/src/test/kotlin/app/batch/HttpWriterTest.kt
+++ b/src/test/kotlin/app/batch/HttpWriterTest.kt
@@ -276,7 +276,7 @@ class HttpWriterTest {
         verify(exportStatusService, once()).incrementSentCount(filename)
     }
 
-    @Test(expected = WriterException::class)
+    @Test
     fun willNotIncrementFilesSentCountOnFailedPost() {
         val filename = "db.database.collection-000001.txt.gz"
         val decryptedStream = DecryptedStream(ByteArrayInputStream(byteArray), filename, "$s3Path/$filename")
@@ -295,7 +295,11 @@ class HttpWriterTest {
         }
 
         given(httpClientProvider.client()).willReturn(httpClient)
-        httpWriter.write(mutableListOf(decryptedStream))
+
+        val exception = shouldThrow<WriterException> {
+            httpWriter.write(mutableListOf(decryptedStream))
+        }
+        exception.message shouldBe "Failed to post 'exporter-output/job01/db.database.collection-000001.txt.gz': post returned status code 503"
         verifyZeroInteractions(exportStatusService)
     }
 


### PR DESCRIPTION
Add filtering for blocked topics so that we don't send any data we don't want to send (e.g. unencrypted) to Crown.