### PR TITLE
Set status updates.

### DIFF
--- a/src/integration/kotlin/SnapshotSenderIntegrationTest.kt
+++ b/src/integration/kotlin/SnapshotSenderIntegrationTest.kt
@@ -54,12 +54,12 @@ class SnapshotSenderIntegrationTest : StringSpec() {
             successes shouldContainExactlyInAnyOrder listOf("_database_empty_successful.gz", "_database_sent_successful.gz")
         }
 
-        "Export status is 'Success' for no files exported topic" {
-            validateResult(getItemResult("321", "db.database.empty").item, "Success", "0", "0")
+        "Export status is 'Received' for no files exported topic" {
+            validateResult(getItemResult("321", "db.database.empty").item, "Received", "0", "0")
         }
 
-        "Export status is 'Success' for sent topic" {
-            validateResult(getItemResult("111", "db.database.sent").item, "Success", "10", "10")
+        "Export status is 'Sent' for successful topic" {
+            validateResult(getItemResult("111", "db.database.sent").item, "Sent", "10", "10")
         }
 
         "Export status is 'Sent' for sent topic" {

--- a/src/main/kotlin/app/batch/JobCompletionNotificationListener.kt
+++ b/src/main/kotlin/app/batch/JobCompletionNotificationListener.kt
@@ -19,7 +19,6 @@ class JobCompletionNotificationListener(private val successService: SuccessServi
         if (jobExecution.exitStatus.equals(ExitStatus.COMPLETED)) {
             if (sendSuccessIndicator.toBoolean()) {
                 successService.postSuccessIndicator()
-                exportStatusService.setSuccessStatus()
             } else {
                 val status = exportStatusService.setCollectionStatus()
                 if (status == CollectionStatus.NO_FILES_EXPORTED) {

--- a/src/main/kotlin/app/services/impl/DynamoDBExportStatusService.kt
+++ b/src/main/kotlin/app/services/impl/DynamoDBExportStatusService.kt
@@ -50,7 +50,7 @@ class DynamoDBExportStatusService(private val dynamoDB: AmazonDynamoDB): ExportS
                 }
 
                 CollectionStatus.NO_FILES_EXPORTED -> {
-                    val result = dynamoDB.updateItem(setStatusSuccessRequest())
+                    val result = dynamoDB.updateItem(setStatusReceivedRequest())
                     logger.info("Collection status after update",
                         "collection_status" to "${result.attributes["CollectionStatus"]?.s}")
                     CollectionStatus.NO_FILES_EXPORTED
@@ -103,6 +103,7 @@ class DynamoDBExportStatusService(private val dynamoDB: AmazonDynamoDB): ExportS
 
     private fun setStatusSentRequest() = setStatusRequest("Sent")
     private fun setStatusSuccessRequest() = setStatusRequest("Success")
+    private fun setStatusReceivedRequest() = setStatusRequest("Received")
 
     private fun setStatusRequest(status: String) =
             UpdateItemRequest().apply {

--- a/src/test/kotlin/app/batch/JobCompletionNotificationListenerTest.kt
+++ b/src/test/kotlin/app/batch/JobCompletionNotificationListenerTest.kt
@@ -60,7 +60,7 @@ class JobCompletionNotificationListenerTest {
     }
 
     @Test
-    fun willWriteSuccessIndicatorOnSuccessfulCompletionAndNoFilesExported() {
+    fun willCallSetStatusOnSuccessfulCompletionAndNoFilesExported() {
         val jobExecution = mock<JobExecution> {
             on { exitStatus } doReturn ExitStatus.COMPLETED
         }
@@ -79,8 +79,7 @@ class JobCompletionNotificationListenerTest {
         }
         jobCompletionNotificationListener.afterJob(jobExecution)
         verify(successService, times(1)).postSuccessIndicator()
-        verify(exportStatusService, times(1)).setSuccessStatus()
-        verifyNoMoreInteractions(exportStatusService)
+        verifyZeroInteractions(exportStatusService)
         ReflectionTestUtils.setField(jobCompletionNotificationListener, "sendSuccessIndicator", "false")
     }
 

--- a/src/test/kotlin/app/services/impl/DynamoDBExportStatusServiceTest.kt
+++ b/src/test/kotlin/app/services/impl/DynamoDBExportStatusServiceTest.kt
@@ -96,7 +96,7 @@ class DynamoDBExportStatusServiceTest {
     }
 
     @Test
-    fun setSentStatusSetsSuccessStatusIfExportedAndNoFilesExported() {
+    fun setSentStatusSetsReceivedStatusIfExportedAndNoFilesExported() {
 
         val status = mock<AttributeValue> {
             on { s } doReturn "Exported"
@@ -122,7 +122,7 @@ class DynamoDBExportStatusServiceTest {
         given(amazonDynamoDB.getItem(any())).willReturn(getItemResult)
         given(amazonDynamoDB.updateItem(any())).willReturn(mock())
         exportStatusService.setCollectionStatus()
-        verifyUpdateItemRequest("Success")
+        verifyUpdateItemRequest("Received")
     }
 
     @Test


### PR DESCRIPTION
If snapshot sender receives a message from HTME indicating that no
files were exported it sets the status to `Received` and sends the
success indicator.

On receiving the `send-a-success-indicator` message is does that
and leaves the status as-is.

On determining that all exported files have been sent it sets the
status to `Sent` but does not send a success indicator.
